### PR TITLE
chore(dev): Add devcontainer support for doc edition

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:alpine3.17
+RUN apk update
+RUN apk add bash
+RUN apk add git

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// Based on https://github.com/hitsumabushi845/MkDocs-with-Remote-Containers
+{
+    "name": "MkDocs Edition Environment",
+    "dockerFile": "Dockerfile",
+     // Set *default* container specific settings.json values on container create.
+     "settings": {
+        "terminal.integrated.profiles.linux": {
+            "bash": {
+                "path": "/bin/bash",
+                "icon": "terminal-bash"
+            }
+        },
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "debug.javascript.usePreview": false
+    },
+
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "yzhang.markdown-all-in-one",
+        "redhat.vscode-yaml",
+        "shardulm94.trailing-spaces",
+        "oderwat.indent-rainbow"
+    ],
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [8000],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "pip3 install -r .devcontainer/pip-reqs.txt"
+
+    // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+    //"remoteUser": "vscode"
+}

--- a/.devcontainer/pip-reqs.txt
+++ b/.devcontainer/pip-reqs.txt
@@ -1,0 +1,3 @@
+mike
+mkdocs-material
+pymdown-extensions


### PR DESCRIPTION
This PR adds devcontainer support for doc edition. 

Devcontainer configures the environment and deps required for the management of Lamassu Documentation based en mkdocs and mike. 